### PR TITLE
[OTTO-70] "aa" command for drush10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ This rpm contains:
   - Registry rebuild
     - drush dl registry_rebuild-7.x-2.3
 
-These extensions are placed in an installation directory that varies by the Drupal version:
+For Drush 8, these extensions are placed in an installation directory that varies by the Drupal version:
 
 - /etc/drush/drupal-8-drush-commandfiles/extensions
 - /etc/drush/drupal-7-drush-commandfiles/extensions
+
+The site audit tool is also placed in locations specific to Drush 9 / Drush 10:
+
+- /etc/drush/drush-9-extensions/Commands
+- /etc/drush/drush-10-extensions/Commands
 
 Note that for historic reasons, the extensions for Drush 5 are included in the RPM for Drush 5, and are inserted directly into Drush 5's `commands` directory (/opt/drush5/commands). No further updates are anticipated to Drush 5, or the Drush 5 extensions.
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -65,6 +65,8 @@ composer --working-dir="$download_dir/drupal-7-drush-commandfiles/extensions/sit
 mkdir -p "$download_dir/drush-9-commandfiles/Commands"
 composer create-project pantheon-systems/site-audit-tool:$site_audit_tool_version "$download_dir/drush-9-extensions/Commands/site-audit-tool" --no-dev --ignore-platform-reqs
 rm -f "$download_dir/drush-9-extensions/Commands/site-audit-tool/testing"
+mkdir -p "$download_dir/drush-10-extensions"
+cp -r "$download_dir/drush-9-extensions/Commands" "$download_dir/drush-10-extensions"
 mkdir -p "$download_dir/drupal-8-drush-commandfiles"
 cp -r "$download_dir/drush-9-extensions/Commands" "$download_dir/drupal-8-drush-commandfiles"
 


### PR DESCRIPTION
We need to put the Site Audit Tool in the drush-10-specific location.